### PR TITLE
frontend should discover security in common_services

### DIFF
--- a/efe/ezbake-nginx-module/src/main/cpp/connector/NginxAsyncConnector.cpp
+++ b/efe/ezbake-nginx-module/src/main/cpp/connector/NginxAsyncConnector.cpp
@@ -102,7 +102,7 @@ void NginxAsyncConnector::initialize() {
     try {
         _appConfig = ApplicationConfiguration::fromConfiguration(_configuration, _configNamespace);
         _securityClient = ::boost::make_shared< ::ezbake::security::client::AsyncClient>(_configuration,
-                _configNamespace, "system_services");
+                _configNamespace, "common_services");
     } catch (const std::exception &ex) {
         LOG4CXX_ERROR(LOG, "error in initializing nginx connector: " + boost::diagnostic_information(ex));
         throw;


### PR DESCRIPTION
I'm not completely sure this is right, but the security service is definitely announcing in common_services as it's set up now, and this allowed EzFrontend to discover it.
